### PR TITLE
Fix header guard and avoid duplicate pins

### DIFF
--- a/src/podesavanja_piny.h
+++ b/src/podesavanja_piny.h
@@ -15,7 +15,7 @@
 #define PIN_RELEJ_NEPARNE_PLOCE    9
 
 // Čekići
-#define PIN_CEKIC_MUSKI             2
+#define PIN_CEKIC_MUSKI             12
 #define PIN_CEKIC_ZENSKI            3
 
 // Zvona
@@ -29,3 +29,4 @@
 // ESP komunikacija (softverski serijski port primjerice)
 #define PIN_ESP_RX                  6
 #define PIN_ESP_TX                  7
+#endif // PODESAVANJA_PINY_H


### PR DESCRIPTION
## Summary
- close the header guard in `podesavanja_piny.h`
- change `PIN_CEKIC_MUSKI` to use pin `12` so it no longer overlaps with `DCF_PIN`

## Testing
- `make test` *(fails: No rule to make target)*
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_683f718e00c08328a2c5da9e07579121