### PR TITLE
Unify RTC access via time_glob

### DIFF
--- a/src/dcf_decoder.cpp
+++ b/src/dcf_decoder.cpp
@@ -4,6 +4,7 @@
 #include "vrijeme_izvor.h"
 #include <RTClib.h>
 #include "podesavanja_piny.h"
+#include "time_glob.h"
 
 volatile bool edgeDetected = false;
 volatile unsigned long edgeTime = 0;
@@ -58,7 +59,6 @@ void dekodirajFrame() {
              + (bitBuffer[54] << 4) + (bitBuffer[55] << 5) + 2000;
 
   DateTime dt(year, month, day, hour, minute, 0);
-  RTC_DS3231 rtc;
   rtc.adjust(dt);
   setZadnjaSinkronizacija(DCF_VRIJEME, dt);
 }

--- a/src/kazaljke_sata.cpp
+++ b/src/kazaljke_sata.cpp
@@ -4,6 +4,7 @@
 #include <EEPROM.h>
 #include "kazaljke_sata.h"
 #include "podesavanja_piny.h"
+#include "time_glob.h"
 
 const unsigned long TRAJANJE_IMPULSA = 6000UL;
 const int MAKS_PAMETNI_POMAK_MINUTA = 15;
@@ -24,7 +25,7 @@ void inicijalizirajKazaljke() {
 }
 
 void upravljajKazaljkama() {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = rtc.now();
   int ukupnoMinuta = now.hour() * 60 + now.minute();
   if (!impulsUTijeku && now.second() == 0 && now != zadnjeVrijeme) {
     zadnjeVrijeme = now;
@@ -67,7 +68,7 @@ void pomakniKazaljkeNaMinutu(int ciljMinuta, bool pametanMod) {
 }
 
 void kompenzirajKazaljke(bool pametanMod) {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = rtc.now();
   int trenutnaMinuta = now.hour() * 60 + now.minute();
   pomakniKazaljkeNaMinutu(trenutnaMinuta, pametanMod);
 }

--- a/src/lcd_prikaz.cpp
+++ b/src/lcd_prikaz.cpp
@@ -24,7 +24,7 @@ void azurirajLCDPrikaz() {
   if (millis() - zadnjiRefresh < 500) return;
   zadnjiRefresh = millis();
 
-  DateTime now = RTC_DS3231().now();
+  DateTime now = rtc.now();
   char red1[17];
   char red2[17];
 

--- a/src/okretna_ploca.cpp
+++ b/src/okretna_ploca.cpp
@@ -4,6 +4,7 @@
 #include <EEPROM.h>
 #include "okretna_ploca.h"
 #include "podesavanja_piny.h"
+#include "time_glob.h"
 
 const unsigned long POLA_OKRETA_MS = 6000UL;
 const int MAKS_PAMETNI_POMAK_MINUTA = 15; // maksimalno za čekanje umjesto rotacije
@@ -27,11 +28,11 @@ void inicijalizirajPlocu() {
   EEPROM.get(22, offsetMinuta);
   if (offsetMinuta < 0 || offsetMinuta > 15) offsetMinuta = 14;
 
-  prosloVrijeme = RTC_DS3231().now();
+  prosloVrijeme = rtc.now();
 }
 
 void upravljajPločom() {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = rtc.now();
   int sati = now.hour();
   int minuta = now.minute();
   int sekunda = now.second();
@@ -85,7 +86,7 @@ int dohvatiPozicijuPloce() {
 }
 
 void kompenzirajPlocu(bool pametniMod) {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = rtc.now();
   int sati = now.hour();
   int minuta = now.minute();
   if (sati < 5 || sati > 20) return;

--- a/src/rtc_vrijeme.cpp
+++ b/src/rtc_vrijeme.cpp
@@ -3,11 +3,9 @@
 #include <EEPROM.h>
 #include "vrijeme_izvor.h"
 #include "dcf_decoder.h"
+#include "time_glob.h"
 
-static RTC_DS3231 rtc;
-
-// Zadnji izvor sinkronizacije. Spremamo u EEPROM na adresi 30
-String izvorVremena = "RTC";
+// Zadnji izvor sinkronizacije pohranjen je u izvorVremena (time_glob.cpp)
 
 void inicijalizirajRTC() {
     rtc.begin();

--- a/src/synchronizacija.cpp
+++ b/src/synchronizacija.cpp
@@ -4,9 +4,9 @@
 #include "kazaljke_sata.h"
 #include "okretna_ploca.h"
 #include "vrijeme_izvor.h"
+#include "time_glob.h"
 
 void sinkronizirajVrijemeIzvora(const DateTime& novoVrijeme, IzvorVremena izvor) {
-  RTC_DS3231 rtc;
   rtc.adjust(novoVrijeme);
 
   // Spremi izvor

--- a/src/time_glob.h
+++ b/src/time_glob.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <RTClib.h>
 
+extern RTC_DS3231 rtc;
+extern String izvorVremena;
+
 void inicijalizirajSat();
 DateTime dohvatiTrenutnoVrijeme();
 void postaviVrijemeIzNTP(const DateTime& dt);

--- a/src/vrijeme_izvor.cpp
+++ b/src/vrijeme_izvor.cpp
@@ -2,6 +2,7 @@
 #include <EEPROM.h>
 #include <RTClib.h>
 #include "vrijeme_izvor.h"
+#include "time_glob.h"
 
 #define EEPROM_ADRESA_IZVOR 0
 #define EEPROM_ADRESA_VRIJEME 4
@@ -26,7 +27,6 @@ DateTime getZadnjeSinkroniziranoVrijeme() {
 }
 
 bool jeSinkronizacijaZastarjela() {
-  RTC_DS3231 rtc;
   DateTime sad = rtc.now();
   DateTime zadnje = getZadnjeSinkroniziranoVrijeme();
   TimeSpan razlika = sad - zadnje;


### PR DESCRIPTION
## Summary
- expose global RTC and source string in `time_glob`
- reference the shared RTC from all modules
- drop local `RTC_DS3231` instances

## Testing
- `grep -R "RTC_DS3231" -n src | head`

------
https://chatgpt.com/codex/tasks/task_e_683f71945f808328896e773540e9571e