### PR TITLE
Initialize RTC globally and update modules

### DIFF
--- a/src/dcf_decoder.cpp
+++ b/src/dcf_decoder.cpp
@@ -4,6 +4,7 @@
 #include "vrijeme_izvor.h"
 #include <RTClib.h>
 #include "podesavanja_piny.h"
+#include "time_glob.h"
 
 volatile bool edgeDetected = false;
 volatile unsigned long edgeTime = 0;
@@ -58,7 +59,6 @@ void dekodirajFrame() {
              + (bitBuffer[54] << 4) + (bitBuffer[55] << 5) + 2000;
 
   DateTime dt(year, month, day, hour, minute, 0);
-  RTC_DS3231 rtc;
-  rtc.adjust(dt);
+  postaviVrijemeIzDCF(dt);
   setZadnjaSinkronizacija(DCF_VRIJEME, dt);
 }

--- a/src/kazaljke_sata.cpp
+++ b/src/kazaljke_sata.cpp
@@ -4,6 +4,7 @@
 #include <EEPROM.h>
 #include "kazaljke_sata.h"
 #include "podesavanja_piny.h"
+#include "time_glob.h"
 
 const unsigned long TRAJANJE_IMPULSA = 6000UL;
 const int MAKS_PAMETNI_POMAK_MINUTA = 15;
@@ -24,7 +25,7 @@ void inicijalizirajKazaljke() {
 }
 
 void upravljajKazaljkama() {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = dohvatiTrenutnoVrijeme();
   int ukupnoMinuta = now.hour() * 60 + now.minute();
   if (!impulsUTijeku && now.second() == 0 && now != zadnjeVrijeme) {
     zadnjeVrijeme = now;
@@ -67,7 +68,7 @@ void pomakniKazaljkeNaMinutu(int ciljMinuta, bool pametanMod) {
 }
 
 void kompenzirajKazaljke(bool pametanMod) {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = dohvatiTrenutnoVrijeme();
   int trenutnaMinuta = now.hour() * 60 + now.minute();
   pomakniKazaljkeNaMinutu(trenutnaMinuta, pametanMod);
 }

--- a/src/lcd_prikaz.cpp
+++ b/src/lcd_prikaz.cpp
@@ -24,7 +24,7 @@ void azurirajLCDPrikaz() {
   if (millis() - zadnjiRefresh < 500) return;
   zadnjiRefresh = millis();
 
-  DateTime now = RTC_DS3231().now();
+  DateTime now = dohvatiTrenutnoVrijeme();
   char red1[17];
   char red2[17];
 

--- a/src/main.ino
+++ b/src/main.ino
@@ -1,7 +1,7 @@
 // src/main.ino – Glavni program automatike sata
 
 #include "lcd_display.h"
-#include "rtc_vrijeme.h"
+#include "time_glob.h"
 #include "otkucavanje.h"
 #include "zvonjenje.h"
 #include "tipke.h"
@@ -11,7 +11,7 @@
 
 void setup() {
   inicijalizirajLCD();
-  inicijalizirajRTC();
+  inicijalizirajSat();
   inicijalizirajKazaljke();
   inicijalizirajPlocu();
   kompenzirajKazaljke(true);

--- a/src/okretna_ploca.cpp
+++ b/src/okretna_ploca.cpp
@@ -4,6 +4,7 @@
 #include <EEPROM.h>
 #include "okretna_ploca.h"
 #include "podesavanja_piny.h"
+#include "time_glob.h"
 
 const unsigned long POLA_OKRETA_MS = 6000UL;
 const int MAKS_PAMETNI_POMAK_MINUTA = 15; // maksimalno za čekanje umjesto rotacije
@@ -27,11 +28,11 @@ void inicijalizirajPlocu() {
   EEPROM.get(22, offsetMinuta);
   if (offsetMinuta < 0 || offsetMinuta > 15) offsetMinuta = 14;
 
-  prosloVrijeme = RTC_DS3231().now();
+  prosloVrijeme = dohvatiTrenutnoVrijeme();
 }
 
 void upravljajPločom() {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = dohvatiTrenutnoVrijeme();
   int sati = now.hour();
   int minuta = now.minute();
   int sekunda = now.second();
@@ -85,7 +86,7 @@ int dohvatiPozicijuPloce() {
 }
 
 void kompenzirajPlocu(bool pametniMod) {
-  DateTime now = RTC_DS3231().now();
+  DateTime now = dohvatiTrenutnoVrijeme();
   int sati = now.hour();
   int minuta = now.minute();
   if (sati < 5 || sati > 20) return;

--- a/src/synchronizacija.cpp
+++ b/src/synchronizacija.cpp
@@ -4,10 +4,22 @@
 #include "kazaljke_sata.h"
 #include "okretna_ploca.h"
 #include "vrijeme_izvor.h"
+#include "time_glob.h"
 
 void sinkronizirajVrijemeIzvora(const DateTime& novoVrijeme, IzvorVremena izvor) {
-  RTC_DS3231 rtc;
-  rtc.adjust(novoVrijeme);
+  switch (izvor) {
+    case NTP_VRIJEME:
+      postaviVrijemeIzNTP(novoVrijeme);
+      break;
+    case DCF_VRIJEME:
+      postaviVrijemeIzDCF(novoVrijeme);
+      break;
+    case RTC_VRIJEME:
+    case NEPOZNATO_VRIJEME:
+    default:
+      postaviVrijemeRucno(novoVrijeme);
+      break;
+  }
 
   // Spremi izvor
   EEPROM.put(0, (int)izvor);

--- a/src/vrijeme_izvor.cpp
+++ b/src/vrijeme_izvor.cpp
@@ -2,6 +2,7 @@
 #include <EEPROM.h>
 #include <RTClib.h>
 #include "vrijeme_izvor.h"
+#include "time_glob.h"
 
 #define EEPROM_ADRESA_IZVOR 0
 #define EEPROM_ADRESA_VRIJEME 4
@@ -26,8 +27,7 @@ DateTime getZadnjeSinkroniziranoVrijeme() {
 }
 
 bool jeSinkronizacijaZastarjela() {
-  RTC_DS3231 rtc;
-  DateTime sad = rtc.now();
+  DateTime sad = dohvatiTrenutnoVrijeme();
   DateTime zadnje = getZadnjeSinkroniziranoVrijeme();
   TimeSpan razlika = sad - zadnje;
   return razlika.totalseconds() > 86400; // 24h


### PR DESCRIPTION
## Summary
- replace rtc_vrijeme with time_glob in `setup`
- fetch time from global RTC in modules
- update DCF decoder and sync logic to use global setters

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f71ae67988328a51628fcd68e404f