### PR TITLE
Unify RTC initialization

### DIFF
--- a/src/main.ino
+++ b/src/main.ino
@@ -11,7 +11,7 @@
 
 void setup() {
   inicijalizirajLCD();
-  inicijalizirajSat();
+  inicijalizirajRTC();
   inicijalizirajKazaljke();
   inicijalizirajPlocu();
   kompenzirajKazaljke(true);

--- a/src/rtc_vrijeme.cpp
+++ b/src/rtc_vrijeme.cpp
@@ -9,16 +9,6 @@ static RTC_DS3231 rtc;
 // Zadnji izvor sinkronizacije. Spremamo u EEPROM na adresi 30
 String izvorVremena = "RTC";
 
-void inicijalizirajRTC() {
-    rtc.begin();
-    if (rtc.lostPower()) {
-        rtc.adjust(DateTime(F(__DATE__), F(__TIME__)));
-    }
-    EEPROM.get(30, izvorVremena);
-    if (izvorVremena != "NTP" && izvorVremena != "DCF" && izvorVremena != "RU") {
-        izvorVremena = "RTC";
-    }
-}
 
 // Provjera za srednjoeuropsko ljetno računanje vremena
 bool isDST(int dan, int mjesec, int danUTjednu) {

--- a/src/rtc_vrijeme.h
+++ b/src/rtc_vrijeme.h
@@ -1,7 +1,6 @@
 #pragma once
 #include <RTClib.h>
 
-void inicijalizirajRTC();       // pokretanje RTC-a i provjera gubitka napajanja
 bool isDST(int dan, int mjesec, int danUTjednu); // provjera DST razdoblja
 void syncNTP();                 // sinkronizacija RTC-a preko NTP-a (ESP modul)
 void syncDCF();                 // sinkronizacija RTC-a prema DCF77 signalu

--- a/src/time_glob.cpp
+++ b/src/time_glob.cpp
@@ -13,7 +13,7 @@ void azurirajVrijemeIzNTP(const DateTime& dt) {
   azurirajOznakuDana();
 }
 
-void inicijalizirajSat() {
+void inicijalizirajRTC() {
   rtc.begin();
   if (rtc.lostPower()) {
     rtc.adjust(DateTime(F(__DATE__), F(__TIME__))); // postavi na build vrijeme

--- a/src/time_glob.h
+++ b/src/time_glob.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <RTClib.h>
 
-void inicijalizirajSat();
+void inicijalizirajRTC();
 DateTime dohvatiTrenutnoVrijeme();
 void postaviVrijemeIzNTP(const DateTime& dt);
 void azurirajVrijemeIzNTP(const DateTime& dt);


### PR DESCRIPTION
## Summary
- remove duplicate `inicijalizirajRTC` implementation
- rename `inicijalizirajSat` to `inicijalizirajRTC`
- update usage and header declarations

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_683f74cee1b883288239d169838b386b