### PR TITLE
Docs: Rewrite README for toranjskog sata, update AGENTS.md, add technical firmware documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
-# Upute za rad s projektom
+# Upute za rad s projektom toranjskog sata
 
 - Sav tekst u dokumentaciji i komentarima piši na hrvatskom jeziku.
 - README održavaj strukturiran s emoji naslovima i točkastim popisima gdje je moguće.
-- Kod dokumentiraj referiranjem na postojeće funkcije i module unutar `src/` direktorija.
-- Prilikom dodavanja novih uputa naglasi kako se odnose na toranjski sat ili povezane komponente.
+- Kod dokumentiraj referiranjem na postojeće funkcije i module unutar `main/` direktorija (ne `src/`).
+- Svaku novu uputu jasno poveži s toranjskim satom ili povezanim komponentama (kazaljke, okretna ploča, zvona, čekići, sinkronizacija vremena, watchdog/recovery).
+- Pri izmjenama koje diraju EEPROM raspored ili recovery logiku obavezno provjeri usklađenost datoteka `eeprom_konstante.h`, `unified_motion_state.*` i `power_recovery.*`.

--- a/README.md
+++ b/README.md
@@ -1,130 +1,81 @@
-# Automatika sata – Toranjski sustav
+# 🕰️ Automatika toranjskog sata
 
-Ovaj projekt modernizira pogon toranjskog sata korištenjem Arduino Mega 2560, RTC DS3231, LCD 2x16 i ESP-01/ESP-12 za mrežnu sinkronizaciju, uz ULN2803 i relejne izlaze za čekiće, zvona i kazaljke.
+Firmware za **Arduino Mega 2560** koji upravlja toranjskim satom kroz četiri ključna mehanička sklopa:
+- kazaljke,
+- okretna ploča,
+- zvona,
+- čekići (otkucavanje).
 
----
-
-## 🛠️ Glavne funkcionalnosti
-
-- Prikaz točnog vremena i datuma na LCD-u toranjskog ormarića
-- Upravljanje kazaljkama toranjskog sata na način dvostrukih impulsa (1/2 + 1/2 = 1)
-- Upravljanje zvonima (zvonjenje, slavljenje, mrtvačko) i čekićima/batovima
-- Automatsko zakazivanje zvona i slavljenja prema ulazima/štapićima okretne ploče
-- Praćenje izvora vremena (RTC, DCF, NTP, ručno) i spremanje u vanjski 24C32 EEPROM na I2C sabirnici
-- Tipkovnica sa 16 tipki za lokalne postavke i servisne komande
+Sustav koristi **DS3231 RTC** kao primarni izvor vremena, **ESP (Serial3)** za NTP/MQTT integraciju i **24C32 EEPROM** za trajnu pohranu stanja i postavki.
 
 ---
 
-## 🧩 Moduli i ključne funkcije
+## ✨ Glavne funkcionalnosti
 
-- `kazaljke_sata` inicijalizira relejne izlaze, vodi dnevnik položaja u EEPROM-u i kompenzira kazaljke na zadano vrijeme (`inicijalizirajKazaljke()`, `upravljajKazaljkama()`, `kompenzirajKazaljke(bool)`), čime toranjski sat ostaje sinkroniziran s RTC-om.【F:src/kazaljke_sata.cpp†L46-L147】
-- `okretna_ploca` čita pet ulaza ploče, pokreće releje za smjer rotacije te automatizira zvona i slavljenje u koordinaciji s toranjskim rasporedom (`inicijalizirajPlocu()`, `kompenzirajPlocu(bool)`, `obradiUlazePloce(...)`). Ručne korekcije toranjskog vremena moguće su kroz spremanje pozicije ploče i 15-minutnog offseta (`postaviTrenutniPolozajPloce(int)`, `postaviOffsetMinuta(int)`, `dohvatiOffsetMinuta()`). Vremenski raspon rada ploče sada se podešava u postavkama (zadano 05:00–20:45, 00:00–00:00 onemogućuje ploču).【F:src/okretna_ploca.cpp†L92-L219】【F:src/okretna_ploca.cpp†L235-L307】
-- `zvonjenje` definira sekvence zvonjenja, upravlja trajanjima i sigurnosnim odgodama te sinkronizira slavljenje i mrtvačko zvono (`inicijalizirajZvona()`, `upravljajZvonom()`, `zapocniSlavljenje()`).【F:src/zvonjenje.cpp†L61-L153】
-- `esp_serial` otvara UART1 prema ESP-01/ESP-12 te obrađuje NTP i naredbe zvona (`inicijalizirajESP()`, `obradiESPSerijskuKomunikaciju()`).【F:src/esp_serial.cpp†L8-L45】
-- `pc_serial` otvara USB serijski port prema PC-u i ispisuje vremenski označene logove za lakše praćenje integracije s toranjskim satom (`inicijalizirajPCSerijsku()`, `posaljiPCLog(...)`).【F:src/pc_serial.cpp†L1-L39】
-- `time_glob` i `vrijeme_izvor` spremaju izvor vremena, ručna i NTP ažuriranja te nadziru starost sinkronizacije, što je ključno za toranjski raspored zvona.【F:src/time_glob.cpp†L12-L44】【F:src/vrijeme_izvor.cpp†L7-L34】
-- `dcf_sync` nadzire DCF77 antenu samo u noćnom prozoru, provjerava stabilizaciju signala i šalje vrijeme toranjskog sata u `time_glob` kada NTP nije dostupan.【F:src/dcf_sync.cpp†L9-L80】
-- `otkucavanje` planira i ispaljuje udarce čekića za sate i polasate, poštujući blokade, vremenske intervale i stanje zvonjenja kako bi mehanički sklopovi toranjskog sata ostali zaštićeni.【F:src/otkucavanje.cpp†L61-L131】
-- `postavke` sprema trajanja udaraca, zvona i vremenske raspone otkucavanja u EEPROM te osigurava sigurne granice za toranjski ormar (čekići, slavljenje, radni/nedjeljni režim).【F:src/postavke.cpp†L6-L153】
-- `tipke` debounca šest tipki, otvara zaslon postavki i omogućuje uređivanje kazaljki, vremena i trajanja zvona u hodu, uz jasne LCD poruke za tehničara toranjskog sata.【F:src/tipke.cpp†L69-L446】
-- `watchdog` uključuje i osvježava AVR watchdog timer (8 s) kako bi toranjski upravljač pouzdano resetirao u slučaju zastoja petlje.【F:src/watchdog.cpp†L10-L27】
+- Sinkronizacija vremena preko RTC-a, NTP-a i DCF77.
+- Dinamička korekcija kazaljki korak-po-korak (bez agresivnih skokova).
+- Dvofazno upravljanje okretnom pločom (PARNI/NEPARNI relej).
+- Automatsko i ručno upravljanje zvonima.
+- Satno i polusatno otkucavanje čekića uz podršku za tihi period.
+- Recovery nakon watchdog/power-loss reseta uz periodično spremanje kritičnog stanja.
+- LCD izbornik s 6 tipki za lokalne postavke.
 
 ---
 
-## 📦 Komponente
+## 🧱 Arhitektura modula (`main/`)
 
-- Arduino Mega 2560 (glavna kontrolna ploča)
-- ESP-01 / ESP-12 (NTP i udaljene naredbe) integriran na Arduinu
-- RTC DS3231 s baterijom (rezervni izvor vremena) + 24C32
-- LCD 2x16 s I2C adapterom (vizualne informacije u ormaru)
-- ULN2803 i optokapleri (izolacija i pogon toranjskih releja)
-- Relejna pločica 5 V (Finder releji na DIN šini) (kazaljke, okretna ploča, zvona)
-- Tipkovnica: 4x4 matricna tipkovnica (0–9, *, #, A–D) s držanjem tipke `0` za ulazak u servisni izbornik
-- Napajanje: 5 V / 2 A Hi-Link na posebnoj pločici sa osiguračem T 500mA, zatim s MOV i TVS diodom
-
----
-
-## 🖥️ Prikaz na LCD-u
-
-- 📟 **Gornji red** prikazuje sat toranjskog ormara u formatu `HH:MM:SS`. Sekunde trepere samo dok je uključeno servisno blinkanje LCD-a (npr. tijekom usklađivanja kazaljki toranjskog sata), a u uobičajenom radu ostaju stabilne radi mirnog prikaza. Desno od vremena stoji oznaka izvora (`RTC`, `NTP`, `RUC`) iz modula `vrijeme_izvor` te slovna oznaka aktualnog dana u tjednu (`dohvatiOznakuDana()`), što olakšava provjeru sinkronizacije toranjskog sata.【F:main/lcd_display.cpp†L77-L147】
-- 📅 **Donji red** prikazuje kratice dana (`Ned`, `Pon`, ...) i datum u obliku `DD.MM.YYYY`, koristeći podatke iz RTC-a (`DateTime now = dohvatiTrenutnoVrijeme()`), čime servisno osoblje odmah vidi kalendarske informacije toranjskog ormara.【F:src/lcd_display.cpp†L49-L74】
-- 🔁 **Poruke i blinkanje** privremeno brišu standardni prikaz: kada `prikaziPoruku()` stigne iz drugih modula, oba reda se pune prilagođenim tekstom, a funkcija `postaviLCDBlinkanje()` uključuje ili isključuje pulsiranje pozadinskog osvjetljenja svakih 500 ms kako bi upozorenja za toranjski sat bila uočljiva.【F:src/lcd_display.cpp†L24-L47】【F:src/lcd_display.cpp†L76-L118】
+- `main.ino` – orkestracija inicijalizacije i glavne petlje.
+- `time_glob.*` – rad s vremenom (RTC/NTP/DCF status i fallback logika).
+- `esp_serial.*` – serijska komunikacija s ESP-om (`NTP:`, `CMD:`, `MQTT:`).
+- `kazaljke_sata.*` – upravljanje koracima kazaljki i sinkronizacijom prema vremenu.
+- `okretna_ploca.*` – logika ciljne pozicije i dvofaznih koraka ploče.
+- `zvonjenje.*` – upravljanje zvonima i inercijom.
+- `otkucavanje.*` – satno/polusatno otkucavanje, slavljenje i mrtvačko.
+- `menu_system.*` + `tipke.*` – korisnički izbornik i ulaz s tipki.
+- `postavke.*` – učitavanje/spremanje postavki i validacija integriteta.
+- `unified_motion_state.*` – jedinstveni model stanja kazaljki + ploče.
+- `power_recovery.*` + `watchdog.*` – sigurnost rada 24/7.
+- `wear_leveling.*` + `i2c_eeprom.*` – pristup i raspodjela zapisa u 24C32 EEPROM.
 
 ---
 
-## 🔗 Povezivanje i preporučeni pinovi
+## 🔌 Hardverske komponente
 
-- **Napajanje i zaštita**
-  - 5 V rail napaja Arduino, ULN2803 i releje; zvona i motori ploče ostaju na zasebnim napajanjima uz optičku izolaciju.
-  - Obavezno uzemljenje zajedničke mase između logike i napajanja toranjskog ormara.
-- **I2C sabirnica**
-  - DS3231 i LCD dijele SDA (D20) i SCL (D21) linije Mega kontrolera, s kratkim vodičima radi otpornika pull-up.
-- **Releji kazaljki**
-  - PIN_RELEJ_PARNE_KAZALJKE (D10) i PIN_RELEJ_NEPARNE_KAZALJKE (D11) vode dvije faze impulsa kazaljki preko ULN2803 u relejne zavojnice.【F:src/podesavanja_piny.h†L7-L10】
-- **Releji okretne ploče**
-  - PIN_RELEJ_PARNE_PLOCE (D8) pokreće naprijed, a PIN_RELEJ_NEPARNE_PLOCE (D9) natrag; oba izlaza uvode se preko optokaplera radi zaštite mehanizma toranjske ploče.【F:src/podesavanja_piny.h†L11-L13】
-- **Ulazi okretne ploče**
-  - PIN_PLOCA_ULAZ_1–5 (D30–D34) koriste interno povlačenje i čitaju reed sklopke / čavle koji najavljuju raspored zvona i slavljenja.【F:src/podesavanja_piny.h†L15-L20】
-- **Tipkovnica**
-  - PIN_TIPKOVNICA_RED1–PIN_TIPKOVNICA_RED4 (D40–D43) nose redove, a PIN_TIPKOVNICA_STUPAC1–PIN_TIPKOVNICA_STUPAC4 (D44–D47) stupce 4x4 tipkovnice; `tipke` modul koristi `Keypad` biblioteku i čeka držanje tipke `0` dvije sekunde za ulazak u izbornik, dok tipke B/C navigiraju, A potvrđuje, a D izlazi iz postavki toranjskog sata.【F:src/podesavanja_piny.h†L22-L29】【F:src/tipke.cpp†L17-L108】【F:src/tipke.cpp†L747-L787】
-- **Zvonjenja i čekići**
-  - PIN_ZVONO_MUSKO (D4) i PIN_ZVONO_ZENSKO (D5) vode zavojnice zvona, dok PIN_CEKIC_MUSKI (D12) i PIN_CEKIC_ZENSKI (D3) upravljaju čekićima preko releja ili SSR-a.【F:src/podesavanja_piny.h†L30-L39】
-- **Slavljenje i eksterni signali**
-  - PIN_SLAVLJENJE_SIGNAL (D2) prati ulaz s procesne logike (aktivno LOW) za ručno pokretanje slavljenja.【F:src/podesavanja_piny.h†L34-L35】
-- **ESP komunikacija**
-  - ESP-01/ESP-12 se interno spaja na hardware UART3 (RX1=D19, TX1=D18) uz level shifting na 3.3 V; `Serial3` se inicijalizira na 9600 bps u `esp_serial` modulu.【F:src/esp_serial.cpp†L8-L26】
-- **DCF77 sinkronizacija**
-  - PIN_DCF_SIGNAL (D18) povezuje se na izlaz DCF antene koja radi kao otvoreni kolektor; masa (DCF−) ide na GND, a napajanje (smeđa žica) na +5 V preko vanjskog otpornika od 10 kΩ koji drži liniju u stanju HIGH dok antena ne zatvori tranzistor.
+- Arduino Mega 2560
+- DS3231 RTC + 24C32 EEPROM (I2C)
+- ESP modul (UART3)
+- LCD 2x16 (I2C)
+- Relejni izlazi za kazaljke, ploču, zvona i čekiće
+- DCF77 prijemnik
+- 6 tipki za izbornik + 2 tipke (slavljenje/mrtvačko) + 2 ručne sklopke zvona
 
 ---
 
-## 🔌 ESP serijska komunikacija
+## 🧭 Brzi pregled rada
 
-- Serial1 (9600 bps) prima `NTP:` vremenske oznake i `CMD:` naredbe za zvona, svaka završena novim redom.
-- Nakon uspješne obrade Arduino vraća `ACK:NTP` ili `ACK:CMD_OK`, dok pogreške daju `ERR:CMD` ili `ERR:FORMAT`, čime toranjski sustav olakšava integraciju s Home Assistantom ili vlastitim nadzornim serverom.【F:src/esp_serial.cpp†L17-L38】
-- Dostupne `CMD:` naredbe omogućuju udaljeni nadzor toranjskog sata preko Home Assistanta i MQTT-a:
-  - `ZVONO1_ON` / `ZVONO1_OFF` – aktivacija i deaktivacija muškog zvona.
-  - `ZVONO2_ON` / `ZVONO2_OFF` – aktivacija i deaktivacija ženskog zvona.
-  - `OTKUCAVANJE_ON` / `OTKUCAVANJE_OFF` – uključenje ili privremena blokada automatskih otkucaja čekića iz modula `otkucavanje`.
-  - `SLAVLJENJE_ON` / `SLAVLJENJE_OFF` – ručno pokretanje ili gašenje slavljenja.
-  - `MRTVACKO_ON` / `MRTVACKO_OFF` – pokretanje ili zaustavljanje mrtvačkog brecanja preko modula `zvonjenje`.
-
-## 🖨️ PC serijska komunikacija
-
-- USB serijski port (`Serial`, 115200 bps) otvara se u `setup()` preko `inicijalizirajPCSerijsku()` kako bi tehničar mogao gledati logove na računalu.
-- Svaka pristigla NTP poruka ili `CMD:` naredba iz ESP-a dobiva vremenski označen zapis (`[LOG] YYYY-MM-DD HH:MM:SS - ...`) preko `posaljiPCLog(...)`, što olakšava otklanjanje grešaka pri sinkronizaciji i upravljanju zvonima toranjskog sata.【F:src/esp_serial.cpp†L23-L78】【F:src/pc_serial.cpp†L12-L39】
+1. `setup()` inicijalizira vrijeme, postavke, ulaze/izlaze, module i recovery.
+2. `loop()` ciklički obrađuje:
+   - komunikaciju i UI,
+   - zvona i čekiće,
+   - kazaljke i ploču,
+   - sinkronizaciju i periodično spremanje stanja.
+3. Watchdog se osvježava u petlji da sustav ostane stabilan u 24/7 radu.
 
 ---
 
-## 📁 Struktura projekta (src/)
+## 📚 Dokumentacija
 
-```
-src/
-├── main.ino               # Glavna petlja i inicijalizacija toranjskog sustava
-├── esp_serial.*           # NTP sinkronizacija i udaljene naredbe
-├── pc_serial.*            # USB serijski logovi prema servisnom PC-u
-├── kazaljke_sata.*        # Upravljanje kazaljkama
-├── lcd_display.*          # Prikaz poruka i menija
-├── okretna_ploca.*        # Rotacija ploče i vanjski ulazi
-├── otkucavanje.*          # Čekići i otkucaji
-├── postavke.*             # EEPROM postavke
-├── tipke.*                # Tipkovnica i izbornici
-├── time_glob.*            # Globalno vrijeme i izvori
-├── zvonjenje.*            # Zvona, slavljenje i mrtvačko
-└── vrijeme_izvor.*        # Evidencija zadnje sinkronizacije
-```
+- Tehnička dokumentacija ponašanja sustava:
+  - `docs/tehnicka_dokumentacija_firmware_sustava.md`
+- Analiza modularnosti menija/tipki/postavki:
+  - `docs/analiza_modularnosti_meni_tipke_postavke.md`
 
 ---
 
-## 🔄 Buduće nadogradnje
+## 🛡️ Napomena za razvoj
 
-- Test mod s LED indikacijom umjesto releja za brzu provjeru u radionici
+Kod promjena koje diraju toranjski sat i povezane komponente (kazaljke, ploča, zvona, čekići), obavezno:
+- sačuvati kompatibilnost EEPROM zapisa,
+- zadržati neblokirajući rad glavne petlje,
+- potvrditi da watchdog i recovery putanje ostaju funkcionalne.
 
----
-
-## 📝 Licenca
-
-Projekt je slobodan za edukaciju i osobnu upotrebu.
-
----
-Za sve komentare, prijedloge ili izmjene slobodno otvori issue na GitHubu ✍️

--- a/docs/tehnicka_dokumentacija_firmware_sustava.md
+++ b/docs/tehnicka_dokumentacija_firmware_sustava.md
@@ -1,0 +1,298 @@
+# 📘 Tehnička dokumentacija firmware sustava toranjskog sata
+
+Ovaj dokument opisuje **kako sustav radi u pogonu**: mehaničko kretanje kazaljki, okretne ploče, zvona i čekića, sinkronizaciju vremena te sigurnosne mehanizme. Fokus je na ponašanju i razlozima dizajna, ne na prepisivanju implementacije.
+
+---
+
+## 1. SYSTEM OVERVIEW
+
+### Što sustav kontrolira
+Firmware upravlja četirima glavnim podsustavima toranjskog sata:
+- **Kazaljke sata** (minutni koraci kroz releje PARNI/NEPARNI).
+- **Okretna ploča** (diskretne pozicije koje predstavljaju raspored mehaničkih događaja).
+- **Zvona** (dulji rad releja zvona, uključujući ručni override i automatske ulaze s ploče).
+- **Čekiće / otkucavanje** (kratki impulsi za puni sat, pola sata, slavljenje i mrtvačko).
+
+### Koncept glavne runtime petlje
+Glavna `loop()` petlja je organizirana kao **kooperativni scheduler** bez blokiranja:
+1. osvježi watchdog,
+2. obradi komunikacije i UI (ESP, meni, tipke),
+3. obradi mehaniku (zvona, otkucavanje, kazaljke, ploča),
+4. obradi dodatnu sinkronizaciju (DCF),
+5. periodički spremi kritično stanje,
+6. ponovno osvježi watchdog.
+
+Time se osigurava da nijedan podsustav ne „gladuje“, a svi rade ciklički u malim koracima.
+
+### Arhitektura na visokoj razini
+- **Vrijeme i sinkronizacija:** `time_glob.*`, `esp_serial.*`, `dcf_sync.*`.
+- **Kretanje mehanike:** `kazaljke_sata.*`, `okretna_ploca.*`, `unified_motion_state.*`.
+- **Udari i zvona:** `otkucavanje.*`, `zvonjenje.*`.
+- **UI i postavke:** `tipke.*`, `menu_system.*`, `postavke.*`.
+- **Otpornost i oporavak:** `watchdog.*`, `power_recovery.*`, `wear_leveling.*`, `i2c_eeprom.*`.
+
+---
+
+## 2. UNIFIED STATE MODEL
+
+### Uloga `UnifiedMotionState`
+`UnifiedMotionState` je jedinstveni zapis stanja za **kazaljke + okretnu ploču**. Ideja je da oba mehanizma dijele isti model i isto spremanje, pa se nakon restarta točno zna:
+- gdje je sustav stao,
+- je li impuls bio aktivan,
+- koja je faza koraka bila u tijeku.
+
+### Značenje polja
+- **`hand_position`**: logička pozicija kazaljki u rasponu 0–719 (12 h × 60 min).
+- **`hand_active`**: `0/1` zastavica je li trenutno aktivan impuls kazaljki.
+- **`hand_relay`**: koji relej vodi impuls kazaljki (`nijedan`, `PARNI`, `NEPARNI`).
+- **`plate_position`**: trenutna pozicija okretne ploče (0–63).
+- **`plate_phase`**: faza ploče (`stabilno`, `prvi relej`, `drugi relej`).
+
+### Cache vs EEPROM
+Sloj `UnifiedMotionStateStore` koristi dvije razine:
+- **RAM cache (`cacheStanje`)** za brzo čitanje bez nepotrebnog I2C prometa.
+- **EEPROM (wear-leveling)** za trajnost kroz nestanak napajanja.
+
+Tok rada:
+1. kod čitanja prvo pokušava cache,
+2. ako cache nije inicijaliziran, čita iz EEPROM-a,
+3. ako EEPROM nije valjan, radi migraciju/rekonstrukciju inicijalnog stanja i odmah ga zapisuje.
+
+### Kada se stanje sprema
+Stanje se sprema **samo kad postoji promjena** (memcmp provjera):
+- pri startu/stopu impulsa kazaljki,
+- pri promjeni faze ploče,
+- pri dovršetku koraka i promjeni pozicije,
+- pri ručnom postavljanju pozicija.
+
+To smanjuje trošenje EEPROM-a i zadržava konzistentnost mehanike.
+
+---
+
+## 3. CLOCK HANDS (KAZALJKE)
+
+### Minutni korak: jedan impuls = jedna minuta
+Kazaljke ne „skaču“ na cilj odmah. Svaki fizički korak radi ovako:
+- aktivira se odgovarajući relej,
+- drži se aktivnim **6 sekundi**,
+- zatim se korak zaključuje i `hand_position` se poveća za 1.
+
+### Parni/neparni relejni model
+Relej se bira prema paritetu trenutne logičke pozicije:
+- parna pozicija → PARNI relej,
+- neparna pozicija → NEPARNI relej.
+
+Tako je svaki idući minutni korak električki konzistentan s mehanikom pogona.
+
+### 6-sekundni impulsni model
+Sustav periodički provjerava treba li novi korak tek nakon isteka faznog vremena. U praksi to znači:
+- dok je impuls aktivan, ne pokreće se novi,
+- tek nakon 6 s impuls se gasi i pozicija napreduje.
+
+### Kako se ispravlja mismatch prema RTC-u (korak-po-korak)
+Cilj je uvijek `RTC vrijeme -> (sat % 12)*60 + minuta`.
+Ako `hand_position != cilj`:
+1. pokrene se jedan korak,
+2. pričeka završetak koraka,
+3. ponovno izračuna cilj,
+4. po potrebi ponovi.
+
+**Primjer:**
+- RTC kaže 10:15 (cilj 615),
+- kazaljke su na 10:12 (612),
+- sustav odradi 3 uzastopna koraka (svaki 6 s),
+- nakon trećeg koraka stanje je sinkronizirano.
+
+Ovo je namjerno „meka“ korekcija radi zaštite mehanike.
+
+---
+
+## 4. ROTATING PLATE (OKRETNA PLOČA)
+
+### Logika koraka svakih 15 minuta
+Ciljna pozicija ploče se računa iz vremena u 15-minutnim blokovima. Aktivni dnevni prozor je:
+- **od 04:59 do 20:44**,
+- izvan tog prozora cilj je noćna pozicija 63.
+
+### Dvofazni model (PARNI + NEPARNI)
+Jedan korak ploče nije trenutan, nego ide kroz dvije faze:
+1. faza 1: prvi relej aktivan 6 s,
+2. faza 2: drugi relej aktivan 6 s,
+3. završetak: `plate_position = (plate_position + 1) % 64`, faza vraćena na stabilno.
+
+### Mapiranje pozicija 0–63
+- `0` odgovara početku dnevnog prozora,
+- svaka iduća pozicija predstavlja +15 min,
+- `63` je zadnja/noćna referenca.
+
+### Sinkronizacija ploče nakon nestanka napajanja
+Kod boota sustav učitava zadnje poznato stanje iz EEPROM-a (pozicija + faza). Nakon toga u runtime-u:
+- ako je ploča već na cilju, nema pokreta,
+- ako nije, korigira se korak-po-korak dok ne dođe do cilja.
+
+Time se izbjegava agresivno „premotavanje“ ploče.
+
+---
+
+## 5. HAMMER STRIKING (OTKUCAVANJE)
+
+### Puni sat vs pola sata
+- **Puni sat (`minute == 00`)**: broj udaraca 1–12 (12-satni format), muški čekić.
+- **Pola sata (`minute == 30`)**: jedan udarac, ženski čekić.
+
+### Tajming
+Za satno otkucavanje sekvenca je fiksirana:
+- **150 ms impuls** čekića,
+- **2 s pauza** između udaraca.
+
+Za ostale načine mogu se koristiti postavke, ali puni sat ostaje fiksan radi predvidljivog mehaničkog ritma.
+
+### Quiet hours logika
+Prije automatskog otkucavanja provjeravaju se:
+- dopušteni satni raspon (`satOd`–`satDo`),
+- tihi period (`tihiSatiOd`–`tihiSatiDo`, uključujući raspon preko ponoći).
+
+Ako je aktivan tihi period, otkucavanje se preskače i samo se logira događaj.
+
+### Interakcija s inercijom i blokadom
+Ako su zvona aktivna ili je svježe završilo zvonjenje, aktivna je inercijska blokada i čekići se ne pokreću. Također postoji korisnička globalna blokada otkucavanja. Ako blokada nastupi usred sekvence, sekvenca se sigurno prekida.
+
+---
+
+## 6. BELLS (ZVONA)
+
+### Razlika između zvona i čekića
+- **Zvona**: dulja aktivacija releja (sekunde/minute), vezana uz ulaze ploče, ručne sklopke i automatsko trajanje.
+- **Čekići**: kratki impulsni udari (stotine ms) za otkucavanje i posebne načine.
+
+### Ručno upravljanje preko sklopki
+Postoje fizičke sklopke za BELL1 i BELL2 (debounce ~30 ms). Kada je ručni override aktivan, on ima prioritet nad automatikom.
+
+### Inercija
+Nakon uključivanja/isključivanja zvona aktivira se inercija od **90 s**. U tom periodu se blokiraju udari čekića da se ne preklapa mehaničko gibanje.
+
+### Zašto se zvona više ne koriste za satno otkucavanje
+Satno otkucavanje je sada prebačeno na čekiće jer traži precizan impulsni ritam (150 ms + pauza). Zvona ostaju za duže liturgijske/rasporedne događaje i ručne intervencije.
+
+---
+
+## 7. NTP / RTC SINKRONIZACIJA
+
+### RTC (DS3231) kao primarni izvor
+Sustav kontinuirano čita DS3231 i to je lokalni autoritet vremena tijekom normalnog rada.
+
+### ESP NTP kao periodička korekcija
+NTP dolazi serijski od ESP-a u strogom ISO formatu (`NTP:YYYY-MM-DDTHH:MM:SS[Z]`). Kad je prihvaćen, vrijeme se upisuje i u RTC.
+
+### Pravilo „samo jednom po satu“ (minuta 00)
+NTP se prihvaća samo ako:
+- je minuta `00`,
+- taj sat još nije prihvaćen (satni ključ godina+mjesec+dan+sat).
+
+### `ACK:NTP` vs `SKIP:NTP`
+- **`ACK:NTP`**: NTP je valjan i prihvaćen.
+- **`SKIP:NTP`**: poruka valjana, ali odbijena pravilom (minuta nije 00 ili je taj sat već obrađen).
+
+Nakon `ACK:NTP`, sustav pokreće „budnu“ korekciju kazaljki ako nisu sinkronizirane.
+
+---
+
+## 8. MENU I SUSTAV POSTAVKI
+
+### Jasna podjela odgovornosti
+- **`tipke.cpp`**: fizičko skeniranje tipki + debounce + pretvorba u `KeyEvent`.
+- **`menu_system.cpp`**: stanje UI-a, ekrani, navigacija, logika potvrde i poziv poslovnih funkcija.
+- **`postavke.cpp`**: trajna pohrana, validacija, fallback na default i zapis u EEPROM.
+
+### Kako se postavke mijenjaju i spremaju
+1. korisnik promijeni vrijednost kroz meni,
+2. `menu_system` pozove API iz `postavke` (npr. tihi sati, MQTT),
+3. `postavke` validira, pripremi integritet (potpis/verzija/checksum),
+4. zapis ide kroz wear-leveling slotove u EEPROM.
+
+### EEPROM verzioniranje i validacija
+Postavke imaju trostruku zaštitu:
+- **potpis** (`POSTAVKE_POTPIS`),
+- **verziju layouta** (`POSTAVKE_VERZIJA`),
+- **checksum** cijele strukture.
+
+Ako bilo što ne prođe validaciju, sustav se vraća na zadane vrijednosti i ponovno ih snima.
+
+---
+
+## 9. BOOT SEQUENCE
+
+### Redoslijed inicijalizacije
+`setup()` redom inicijalizira:
+1. LCD + PC serial,
+2. vanjski EEPROM,
+3. RTC + učitavanje postavki,
+4. tipke, ESP, opcionalno MQTT, meni,
+5. zvona, otkucavanje, kazaljke, ploču, DCF,
+6. watchdog,
+7. power-recovery oznake i boot recovery.
+
+### Watchdog inicijalizacija
+Watchdog se podiže na 8 s timeout i odmah bilježi razlog prethodnog reseta (WDT/BOR/POR/EXTRF).
+
+### Oporavak nakon nestanka napajanja
+Power recovery čita kružni skup backup slotova i traži zadnji valjani zapis (checksum). Ako ga nađe, vraća:
+- poziciju kazaljki,
+- poziciju ploče,
+- offset ploče.
+
+### Obnova stanja iz EEPROM-a
+Kritično stanje se periodički sprema svakih 60 s u rotirajuće slotove. To ograničava gubitak stanja na najviše posljednju minutu prije ispada.
+
+### Inicijalno sinkronizacijsko ponašanje
+Nakon boota sustav ne radi „hard jump“ mehanike. Umjesto toga, mehanizmi uđu u redovni korak-po-korak režim i sami dođu do ciljnog vremena/pozicije.
+
+---
+
+## 10. ERROR HANDLING I SIGURNOST
+
+### Watchdog
+Dvaput u glavnoj petlji se radi `wdt_reset()`. Ako petlja zapne, MCU se resetira i reset-uzrok ostaje logiran za recovery dijagnostiku.
+
+### EEPROM validacija (potpis/verzija/checksum)
+- Postavke: potpis + verzija + checksum.
+- Backup kritičnog stanja: checksum.
+- Unified stanje: rasponi polja + verzija.
+
+### Rukovanje oštećenim postavkama
+Ako su podaci nevaljani:
+- vraća se sigurni default,
+- string polja se sanitiziraju i null-terminiraju,
+- ispravljena struktura se ponovo zapisuje.
+
+### Sprječavanje neispravnih stanja
+- vrijednosti se `constrain`-aju (npr. 0–719, 0–63, 0–14),
+- međusobno isključivi načini (slavljenje vs mrtvačko),
+- zabrana paralelnih sekvenci otkucavanja,
+- sigurno gašenje releja kod prekida i pri inicijalizaciji.
+
+---
+
+## 11. POZNATE DIZAJNERSKE ODLUKE
+
+### Zašto korekcija ide korak-po-korak, a ne agresivni skok
+Mehanika toranjskog sata ima masu i inertnost. Postupna korekcija smanjuje udarna opterećenja, pregrijavanje releja i rizik od mehaničkog preskoka.
+
+### Zašto se koristi unified state
+Jedan izvor istine za kazaljke i ploču smanjuje race-condition scenarije i pojednostavljuje recovery jer se oba pogona oporavljaju iz istog koncepta stanja.
+
+### Zašto je dopušten „blokirajući“ boot recovery
+Kratko determinističko kašnjenje pri bootu je prihvatljivo jer je važnije vratiti mehaniku u konzistentno stanje prije normalnog cikličkog rada. Time se izbjegava start u polu-nepoznatom stanju releja.
+
+### Zašto je NTP ograničen na satne točke
+Satna granularnost (minuta 00) smanjuje jitter i nepotrebne mikrokorekcije kroz dan, a i dalje redovito „zaključava“ vrijeme prema mrežnom izvoru.
+
+---
+
+## 🛠️ Developer notes (ključne zamke)
+
+- `WearLeveling::spremi` koristi statički brojač po tipu/predlošku; pri većim refaktorima paziti na neočekivane obrasce raspodjele zapisa.
+- U `okretna_ploca.cpp` ciljna pozicija je trenutno vezana uz fiksne konstante 04:59–20:44; ako se želi potpuno konfigurabilan prozor, treba uskladiti izračun cilja s postavkama.
+- `power_recovery.cpp` ima vlastitu lokalnu strukturu backupa; kod promjena layouta obavezno uskladiti i `eeprom_konstante.h` i recovery logiku.
+- Ručni override zvona ima prioritet nad automatikom; pri dijagnostici „zašto zvono ne staje“ prvo provjeriti stanje fizičkih sklopki.
+


### PR DESCRIPTION
### Motivation

- Unify and clarify project documentation to focus explicitly on the toranjskog sata (tower clock) firmware and its subsystems. 
- Ensure contributor guidelines require Croatian language in docs and redirect code references to the actual code layout (`main/`), and to highlight EEPROM and recovery compatibility requirements. 
- Provide a single, comprehensive technical reference describing runtime behavior, recovery, and design decisions to reduce ambiguity during development and maintenance.

### Description

- Updated `AGENTS.md` to emphasize Croatian documentation, change code referencing from `src/` to `main/`, and add explicit checks for EEPROM/recovery-related files (`eeprom_konstante.h`, `unified_motion_state.*`, `power_recovery.*`).
- Rewrote `README.md` into a toranjskog sata–focused document with reorganized sections (project overview, main features, module mapping to `main/`, hardware components, quick runtime overview, and developer notes). 
- Removed the previous detailed `src/`-centric listings and pin-by-pin exposition in favor of a concise module/component architecture and high-level hardware summary. 
- Added `docs/tehnicka_dokumentacija_firmware_sustava.md` as a new, detailed technical document covering system overview, unified state model, hands/plate/hammer/bell behavior, synchronization, boot/recovery, and developer notes.

### Testing

- Ran `markdownlint` on the modified documentation files and it completed without errors. 
- Ran `markdown-link-check` on top-level docs to verify internal links and the check passed; no automated code/unit tests were applicable because only documentation was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c589d69168832888b4373057094216)